### PR TITLE
Link Portfiles to GitHub rather than Trac

### DIFF
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -16,6 +16,8 @@ $macports_version_latest = '2.3.4';
 
 # Some useful URL abstractions:
 $trac_url = 'https://trac.macports.org/';
+$github_url = 'https://github.com/macports/';
+$github_url_ports = $github_url . 'macports-ports/';
 $svn_url = 'https://svn.macports.org/repository/macports/';
 $normal_downloads = 'https://distfiles.macports.org/MacPorts/';
 $sf_downloads = 'http://downloads.sourceforge.net/project/macports/MacPorts/' . $macports_version_latest . '/';

--- a/ports.php
+++ b/ports.php
@@ -178,8 +178,9 @@
                  $row = pg_fetch_assoc($result), $i++) {
 
                 /* Port name and Portfile URL */
-                print "<dt><b><a href=\"${trac_url}browser/trunk/dports/" . $row['path'] . "/Portfile\">" . htmlspecialchars($row['name'])
-                . '</a></b> ' . htmlspecialchars($row['version']) . '</dt>';
+                print '<dt><b>' . htmlspecialchars($row['name']) . '</b> ' . htmlspecialchars($row['version'])
+                . ' <i>(<a href="' . htmlspecialchars($github_url_ports . 'blob/master' . $row['path'] . '/Portfile')
+                . '">source</a>)</i></dt>';
                 
                 print '<dd>';
                 /* Port short description */


### PR DESCRIPTION
I expect this part of the webpage will have to be replaced anyway (I don't particularly like the current output), but here's a tiny patch (not tested on a live server installation) that replaces links to trac with links to github and makes it slightly more obvious that links are sources rather than some homepage to the port (as I would probably expect).

  * create a link to
    https://github.com/macports/macports-ports/blob/master/
    rather than
    https://trac.macports.org/browser/trunk/dports/
  * users might expect port's homepage on the link, so replace
    `<b><a href="/url/to/Portfile">$name</a></b> $version`
    with
    `<b>$name</b> $version <i>(<a href="/url/to/Portfile">source</a>)</i>`

Feel free to edit or discard (I have no prior experience with editing the website).