### PR TITLE
Remove leftovers from database connections

### DIFF
--- a/index.php
+++ b/index.php
@@ -90,7 +90,4 @@
 
 <?php
     print_footer();
-    if ($portsdb_info['connection_handler'] !== false) {
-        pg_close($portsdb_info['connection_handler']);
-    }
 ?>


### PR DESCRIPTION
Those caused notices in the server log, and we removed the postgres module, so `pg_close()` is even undefined.